### PR TITLE
fix client connection removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = class HyperswarmProxyStream extends Duplex {
   _addStream (stream) {
     this.connections.add(stream)
     stream.once('close', () => {
-      this.connections.remove(stream)
+      this.connections.delete(stream)
     })
   }
 


### PR DESCRIPTION
use [`Set.delete`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/delete) (instead of `Set.remove`). throws for me when client connections are closed.