### PR TITLE
add switch for handling closed server streams

### DIFF
--- a/client.js
+++ b/client.js
@@ -67,6 +67,9 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
     this.emit('connection', stream, details)
 
     stream.once('close', () => {
+      if (this.destroyed) {
+        return
+      }
       this.emit('disconnection', stream, details)
       this._connectedPeers.delete(peer)
     })


### PR DESCRIPTION
if client proxy swarms are destroyed manually via `swarm.destroy()`, connections to proxy servers are closed too.
https://github.com/RangerMauve/hyperswarm-proxy/blob/4bff3fc1fd4d9684967ae0b6b9439298f13ab793/client.js#L154

however, proxy stream 'close' events are emitted a bit delayed, so that their handlers are called _after_ the swarm has been destroyed and cleaned up:
https://github.com/RangerMauve/hyperswarm-proxy/blob/4bff3fc1fd4d9684967ae0b6b9439298f13ab793/client.js#L69-L72

as `this._connectedPeers` is already null, this handler will fail. i propose to void this handler if `this.destroyed == true`, as `disconnection` events might be without interest anyway after the swarm got destroyed. we might alternatively store these handlers and remove them during destroy.