### PR TITLE
Added fixes for issues discovered during hyperswarm-proxy-ws implementation

### DIFF
--- a/client.js
+++ b/client.js
@@ -33,8 +33,8 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
     }
   }
 
-  disconnect() {
-    if(!this._protocol) {
+  disconnect () {
+    if (!this._protocol) {
       return
     }
     this._protocol.removeListener('close', this._handleClose)
@@ -63,7 +63,7 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
   }
 
   _handleStream (stream, { topic, peer }) {
-    if(this.destroyed) {
+    if (this.destroyed) {
       // Already destroyed
       stream.end()
       return
@@ -95,7 +95,7 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
 
   _handleClose () {
     this._protocol = null
-    for(let peer of this._connectedPeers) {
+    for (const peer of this._connectedPeers) {
       peer.end()
     }
     this.emit('disconnected')

--- a/client.js
+++ b/client.js
@@ -14,9 +14,11 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
     this._handleStream = this._handleStream.bind(this)
     this._handleClose = this._handleClose.bind(this)
     this._handlePeer = this._handlePeer.bind(this)
+    this._handleError = this._handleError.bind(this)
     this._reJoin = this._reJoin.bind(this)
 
     this._protocol = null
+    this._connection = null
 
     this._topics = []
     this._connectedPeers = new Set()
@@ -31,18 +33,28 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
     }
   }
 
-  reconnect (connection) {
-    if (this._protocol) {
-      this._protocol.removeListener('close', this._handleClose)
-      this._protocol.end()
-      this._protocol = null
+  disconnect() {
+    if(!this._protocol) {
+      return
     }
+    this._protocol.removeListener('close', this._handleClose)
+    this._connection.end()
+    this._protocol.end()
 
+    this._connection = null
+    this._protocol = null
+  }
+
+  reconnect (connection) {
+    this.disconnect()
+
+    this._connection = connection
     this._protocol = new HyperswarmProxyStream(connection)
 
     this._protocol.on('stream', this._handleStream)
     this._protocol.on('on_peer', this._handlePeer)
     this._protocol.once('close', this._handleClose)
+    this._protocol.on('error', this._handleError)
 
     // Once the other side is ready, re-join known topics
     this._protocol.once('ready', this._reJoin)
@@ -51,6 +63,12 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
   }
 
   _handleStream (stream, { topic, peer }) {
+    if(this.destroyed) {
+      // Already destroyed
+      stream.end()
+      return
+    }
+
     const details = {
       type: 'proxy',
       client: true,
@@ -67,6 +85,9 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
     this.emit('connection', stream, details)
 
     stream.once('close', () => {
+      if (this.destroyed) {
+        return
+      }
       this.emit('disconnection', stream, details)
       this._connectedPeers.delete(peer)
     })
@@ -74,7 +95,14 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
 
   _handleClose () {
     this._protocol = null
+    for(let peer of this._connectedPeers) {
+      peer.end()
+    }
     this.emit('disconnected')
+  }
+
+  _handleError (e) {
+    this.emit('error', e)
   }
 
   _handlePeer ({ topic, peer }) {
@@ -145,15 +173,13 @@ module.exports = class HyperswarmProxyClient extends EventEmitter {
   }
 
   destroy (cb) {
-    if (this._protocol) {
-      this._protocol.removeListener('close', this._handleClose)
-      this._protocol.end()
-    }
+    this.destroyed = true
+
+    this.disconnect()
 
     this._topics = null
     this._connectedPeers = null
     this._seenPeers = null
-    this.destroyed = true
 
     if (cb) process.nextTick(cb)
   }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = class HyperswarmProxyStream extends Duplex {
       lps.decode(),
       this,
       lps.encode(),
-      stream, (err) => {
+      stream, () => {
         this._closeAllStreams()
       })
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://github.com/RangerMauve/hyperswarm-proxy#readme",
   "dependencies": {
     "@hyperswarm/network": "^1.0.3",
-    "length-prefixed-stream": "^2.0.0"
+    "length-prefixed-stream": "^2.0.0",
+    "pump": "^3.0.0"
   },
   "devDependencies": {
     "duplexpair": "^1.0.1",

--- a/proxystream.js
+++ b/proxystream.js
@@ -2,7 +2,9 @@ var Duplex = require('stream').Duplex
 
 module.exports = class ProxyStream extends Duplex {
   constructor (protocol, id) {
-    super()
+    super({
+      emitClose: true
+    })
     this._secretId = Math.random()
     this._id = id
     this._protocol = protocol
@@ -25,7 +27,7 @@ module.exports = class ProxyStream extends Duplex {
 
   _handleClose ({ stream }) {
     if (this._isId(stream)) {
-      this.end()
+      this.destroy()
       this._cleanup()
     }
   }
@@ -34,7 +36,7 @@ module.exports = class ProxyStream extends Duplex {
     if (this._isId(stream)) {
       const message = data.toString('utf8')
       this.emit('error', new Error(message))
-      this.end()
+      this.destroy()
       this._cleanup()
     }
   }

--- a/server.js
+++ b/server.js
@@ -19,7 +19,12 @@ module.exports = class HyperswarmProxyServer extends EventEmitter {
       handleIncoming
     } = opts
 
-    if (handleIncoming) this.handleIncoming = handleIncoming
+    this.shouldAnnounce = false
+
+    if (handleIncoming) {
+      this.handleIncoming = handleIncoming
+      this.shouldAnnounce = true
+    }
 
     this.network = network
 
@@ -35,7 +40,7 @@ module.exports = class HyperswarmProxyServer extends EventEmitter {
     this.network.bind((err) => {
       if (err) return cb(err)
 
-      const client = new Client(stream, this.network)
+      const client = new Client(stream, this.network, this.shouldAnnounce)
 
       this.clients.add(client)
 
@@ -79,7 +84,7 @@ module.exports = class HyperswarmProxyServer extends EventEmitter {
 }
 
 class Client extends HyperswarmProxyStream {
-  constructor (stream, network) {
+  constructor (stream, network, shouldAnnounce) {
     super(stream)
 
     this.network = network
@@ -87,6 +92,7 @@ class Client extends HyperswarmProxyStream {
     this.peerMap = new Map()
     this.connections = new Set()
     this.streamCounter = 0
+    this.shouldAnnounce = shouldAnnounce
 
     this.once('ready', () => {
       this.init()
@@ -148,12 +154,15 @@ class Client extends HyperswarmProxyStream {
       const lookup = this.network.lookup(topic)
       this.lookups.set(lookupString, lookup)
 
-      const announce = this.network.announce(topic)
+      let announce = null
+      if (this.shouldAnnounce) {
+        announce = this.network.announce(topic)
+      }
 
       lookup.on('peer', handlePeer)
       lookup.on('close', () => {
         this.lookups.delete(lookupString)
-        announce.destroy()
+        if (announce) announce.destroy()
       })
     })
   }

--- a/server.js
+++ b/server.js
@@ -97,6 +97,7 @@ class Client extends HyperswarmProxyStream {
     this.on('join', (data) => this.handleJoin(data))
     this.on('leave', (data) => this.handleLeave(data))
     this.on('connect', (data) => this.handleConnect(data))
+    this.ready()
   }
 
   nextStreamId () {


### PR DESCRIPTION
- Make sure `close` event gets emitted when proxied connections end
- End the actual connection that got passed in when disconnecting
- New `disconnect` method to make it cleaner to disconnect a client
- Ignore new streams if already destroyed
- Disconnect peers when closing connection
- Re-emit errors from hyperswarm-proxy stream
- Use `pump` for creating pipeline
- Send `ready` event from the server once it's ready to get messages
- Only announce if a custom `handleIncoming` has been passed to handle the connections.

cc @falafeljan (I'll keep this open for a couple of days while I do some final testing)