### PR TITLE
Update hyperswarm/network

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/RangerMauve/hyperswarm-proxy#readme",
   "dependencies": {
-    "@hyperswarm/network": "^1.3.2",
+    "@hyperswarm/network": "^2.1.0",
     "length-prefixed-stream": "^2.0.0",
     "pump": "^3.0.0"
   },


### PR DESCRIPTION
I was trying to de-dupe some dependencies in [ssb-browser-core](https://github.com/arj03/ssb-browser-core) and noticed that this module was pulling in an old dependency compared to hyperswarm.